### PR TITLE
OBShapedButton Clickability Production

### DIFF
--- a/OBShapedButton/OBShapedButton.m
+++ b/OBShapedButton/OBShapedButton.m
@@ -145,14 +145,16 @@
 // Reset the Hit Test Cache when a new image is assigned to the button
 - (void)setImage:(UIImage *)image forState:(UIControlState)state
 {
-    [super setImage:image forState:state];
-    [self resetHitTestCache];
+  [super setImage:image forState:state];
+  [self getImagesForCurrentState];
+  [self resetHitTestCache];
 }
 
 - (void)setBackgroundImage:(UIImage *)image forState:(UIControlState)state
 {
-    [super setBackgroundImage:image forState:state];
-    [self resetHitTestCache];
+  [super setBackgroundImage:image forState:state];
+  [self getImagesForCurrentState];
+  [self resetHitTestCache];
 }
 
 - (void)setEnabled:(BOOL)enabled{


### PR DESCRIPTION
I have an app where this button is overlaying a map view.  In this scenario the button tends to lose its clickability and allow for the user to touch the map through the button.  After some debugging I found that the button seems to return an alpha of zero occasionally.  It seems to be that setting buttonImage and buttonBackground on each click runs the risk of checking a nil image.  I've added a few methods here that will detect a change in state and generate new images to check.  This should allow for more flexibility with the images.
