### PR TITLE
Change the global alpha threshold to a per button properly

### DIFF
--- a/OBShapedButton/OBShapedButton.h
+++ b/OBShapedButton/OBShapedButton.h
@@ -35,12 +35,11 @@
 
 #import <UIKit/UIKit.h>
 
-// -[UIView hitTest:withEvent: ignores views that an alpha level less than 0.1.
-// So we will do the same and treat pixels with alpha < 0.1 as transparent.
-#define kAlphaVisibleThreshold (0.1f)
-
 @interface OBShapedButton : UIButton
 
-// Class interface is empty. OBShapedButton does not add new public methods.
+// -[UIView hitTest:withEvent: ignores views that an alpha level less than 0.1.
+// So we will do the same and treat pixels with alpha < 0.1 as transparent.
+
+@property (assign, nonatomic) CGFloat alphaVisibleThreshold;
 
 @end

--- a/OBShapedButton/OBShapedButton.m
+++ b/OBShapedButton/OBShapedButton.m
@@ -61,6 +61,8 @@
 
 - (void)setup
 {
+    self.alphaVisibleThreshold = 0.1f; // Defaults to 0.1
+    
     [self updateImageCacheForCurrentState];
     [self resetHitTestCache];
 }
@@ -92,7 +94,7 @@
         CGColorRef cgPixelColor = [pixelColor CGColor];
         alpha = CGColorGetAlpha(cgPixelColor);
     }
-    return alpha >= kAlphaVisibleThreshold;
+    return alpha >= self.alphaVisibleThreshold;
 }
 
 


### PR DESCRIPTION
This seems like a nicer way of specifying the alpha threshold, it defaults to 0.1 as before.
