### PR TITLE
Fixed hit zone issue if image is smaller than button's frame

### DIFF
--- a/OBShapedButton/OBShapedButton.m
+++ b/OBShapedButton/OBShapedButton.m
@@ -125,6 +125,8 @@
 - (BOOL)isAlphaVisibleAtPoint:(CGPoint)point forImage:(UIImage *)image
 {
     // Correction for image scaling including contentmode
+    point.x = point.x - self.imageView.frame.origin.x;
+    point.y = point.y - self.imageView.frame.origin.y;
     CGPoint pt = CGPointApplyAffineTransform(point, self.imageView.viewToImageTransform);
     point = pt;
     


### PR DESCRIPTION
There is an issue when the button's image is smaller than the button itself.

There is just the origin point's coordinates to substract from the actual touch point to get the right calculation going.

Of course it won't change the actual behavior for cases not causing this issue, since the origin would be [0,0] so it isn't affecting anything else.